### PR TITLE
Make SSL client/server hello events compatible with Bro 2.6

### DIFF
--- a/bro/intel_ja3.bro
+++ b/bro/intel_ja3.bro
@@ -17,7 +17,11 @@ export {
     redef enum Intel::Where += { SSL::IN_JA3 };
 }
 
+@if ( Version::at_least("2.6") || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec)
+@else
 event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec)
+@endif
 	{
 	if ( c$ssl?$ja3 )
 	Intel::seen([$indicator=c$ssl$ja3, $indicator_type=Intel::JA3, $conn=c, $where=SSL::IN_JA3]);

--- a/bro/ja3.bro
+++ b/bro/ja3.bro
@@ -115,7 +115,11 @@ event ssl_extension_elliptic_curves(c: connection, is_orig: bool, curves: index_
     }
 }
 
+@if ( Version::at_least("2.6") || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec) &priority=1
+@else
 event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec) &priority=1
+@endif
 {
     if ( !c?$tlsfp )
     c$tlsfp=TLSFPStorage();

--- a/bro/ja3s.bro
+++ b/bro/ja3s.bro
@@ -56,7 +56,11 @@ if ( ! c?$ja3sfp )
     }
 }
 
+@if ( Version::at_least("2.6") || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
+@else
 event ssl_server_hello(c: connection, version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
+@endif
 {
     if ( !c?$ja3sfp )
     c$ja3sfp=JA3Sstorage();


### PR DESCRIPTION
Some SSL event definitions will change in upcoming Bro 2.6.  This PR should change the event handlers to be compatible with that as well as still work with older versions.