### PR TITLE
Bro: add @load directives to make scripts usable in "bare" mode

### DIFF
--- a/bro/intel_ja3.bro
+++ b/bro/intel_ja3.bro
@@ -7,6 +7,9 @@
 # Licensed under the BSD 3-Clause license. 
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 
+@load base/misc/version
+@load base/protocols/ssl
+
 module Intel;
 
 export {

--- a/bro/ja3.bro
+++ b/bro/ja3.bro
@@ -8,6 +8,9 @@
 # Licensed under the BSD 3-Clause license. 
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 
+@load base/misc/version
+@load base/protocols/ssl
+
 module JA3;
 
 export {

--- a/bro/ja3s.bro
+++ b/bro/ja3s.bro
@@ -10,7 +10,8 @@
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 #
 
-
+@load base/misc/version
+@load base/protocols/ssl
 
 module JA3_Server;
 


### PR DESCRIPTION
Hi,

Thanks for this project! I am in the process of using JA3 in the passive network recon part of [IVRE](https://ivre.rocks/), which relies on Bro scripts that can run in "bare" mode (i.e., with Bro `-b` option).

Currently, JA3 scripts won't work because of missing script dependenecies. This will not change anything in how JA3 works with "normal" (without `-b`) mode.