### PR TITLE
Update to version check code to work with bro 2.5

### DIFF
--- a/bro/ja3.bro
+++ b/bro/ja3.bro
@@ -115,7 +115,7 @@ event ssl_extension_elliptic_curves(c: connection, is_orig: bool, curves: index_
     }
 }
 
-@if ( Version::number >= 20600 || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+@if ( ( Version::number >= 20600 ) || ( Version::number == 20500 && Version::info$commit >= 944 ) )
 event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec) &priority=1
 @else
 event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec) &priority=1

--- a/bro/ja3.bro
+++ b/bro/ja3.bro
@@ -115,7 +115,7 @@ event ssl_extension_elliptic_curves(c: connection, is_orig: bool, curves: index_
     }
 }
 
-@if ( Version::at_least("2.6") || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+@if ( Version::number >= 20600 || ( Version::number == 20500 && Version::info$commit >= 944 ) )
 event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec) &priority=1
 @else
 event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec) &priority=1

--- a/bro/ja3s.bro
+++ b/bro/ja3s.bro
@@ -56,7 +56,7 @@ if ( ! c?$ja3sfp )
     }
 }
 
-@if ( Version::at_least("2.6") || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+@if ( ( Version::number >= 20600 ) || ( Version::number == 20500 && Version::info$commit >= 944 ) )
 event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
 @else
 event ssl_server_hello(c: connection, version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1


### PR DESCRIPTION
This function Version::at_least() does not work in bro 2.5. Calling it in 2.5 returns incorrect results and causes bro to load the wrong ssl_client_hello event. This would cause problems for users of JA3 on bro 2.5. 
Error seen is: 
```
error in /usr/local/bro-2.5/share/bro/base/bif/plugins/./Bro_SSL.events.bif.bro, line 33 and ./././ja3.bro, line 119: incompatible types (event(c:connection; version:count; possible_ts:time; client_random:string; session_id:string; ciphers:vector of count;) and event(c:connection; version:count; record_version:count; possible_ts:time; client_random:string; session_id:string; ciphers:vector of count; comp_methods:vector of count;))
error in ./././ja3.bro, line 120: syntax error, at or near "@else"
```
http://try.bro.org/#/trybro/saved/342611

The fix here is to call Version::number.
http://try.bro.org/#/trybro/saved/342610