### PR TITLE
Add support for Linux cooked mode (SLL) PCAPs

### DIFF
--- a/python/ja3.py
+++ b/python/ja3.py
@@ -143,10 +143,15 @@ def process_pcap(pcap, any_port=False):
     :param any_port: Whether or not to search for non-SSL ports
     :type any_port: bool
     """
+    decoder = dpkt.ethernet.Ethernet
+    linktype = pcap.datalink()
+    if linktype == dpkt.pcap.DLT_LINUX_SLL:
+        decoder = dpkt.sll.SLL
+
     results = list()
     for timestamp, buf in pcap:
         try:
-            eth = dpkt.ethernet.Ethernet(buf)
+            eth = decoder(buf)
         except Exception:
             continue
 

--- a/python/ja3/ja3.py
+++ b/python/ja3/ja3.py
@@ -142,10 +142,15 @@ def process_pcap(pcap, any_port=False):
     :param any_port: Whether or not to search for non-SSL ports
     :type any_port: bool
     """
+    decoder = dpkt.ethernet.Ethernet
+    linktype = pcap.datalink()
+    if linktype == dpkt.pcap.DLT_LINUX_SLL:
+        decoder = dpkt.sll.SLL
+
     results = list()
     for timestamp, buf in pcap:
         try:
-            eth = dpkt.ethernet.Ethernet(buf)
+            eth = decoder(buf)
         except Exception:
             continue
 

--- a/python/ja3s.py
+++ b/python/ja3s.py
@@ -127,10 +127,15 @@ def process_pcap(pcap, any_port=False):
     :param any_port: Whether or not to search for non-SSL ports
     :type any_port: bool
     """
+    decoder = dpkt.ethernet.Ethernet
+    linktype = pcap.datalink()
+    if linktype == dpkt.pcap.DLT_LINUX_SLL:
+        decoder = dpkt.sll.SLL
+
     results = list()
     for timestamp, buf in pcap:
         try:
-            eth = dpkt.ethernet.Ethernet(buf)
+            eth = decoder(buf)
         except Exception:
             continue
 


### PR DESCRIPTION
This enables parsing pcaps generated via `tcpdump -i any` and should resolve #15 