### PR TITLE
register maintainer and maintainer email under setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,8 @@ setup(
     url="https://github.com/salesforce/ja3",
     author="Tommy Stallings",
     author_email="tommy.stallings@salesforce.com",
+    maintainer = "John B. Althouse",
+    maintainer_email = "jalthouse@salesforce.com",
     license="BSD",
     packages=find_packages(),
     install_requires=['dpkt'],


### PR DESCRIPTION
In order to automate the creation of a deb file for JA3 using https://github.com/nylas/make-deb. There are two properties missing under the setup.py. After reading the README.md it looks like John B. Althouse is the current maintainer. I am open to correction and set the correct maintainer(s) and their respective email. I just would like to have all those values present in the setup.py file