### PR TITLE
Added dpkt.ssl.SSL3Exception clause

### DIFF
--- a/python/ja3.py
+++ b/python/ja3.py
@@ -204,6 +204,9 @@ def process_pcap(pcap, any_port=False):
             except dpkt.dpkt.NeedData:
                 # Looking for a handshake here
                 continue
+            except dpkt.ssl.SSL3Exception:
+                # Unknown or invalid cipher suite type
+                continue
             if not isinstance(handshake.data, dpkt.ssl.TLSClientHello):
                 # Still not the HELLO
                 continue

--- a/python/ja3/ja3.py
+++ b/python/ja3/ja3.py
@@ -203,6 +203,9 @@ def process_pcap(pcap, any_port=False):
             except dpkt.dpkt.NeedData:
                 # Looking for a handshake here
                 continue
+            except dpkt.ssl.SSL3Exception:
+                #Unknown or invalid cypher suite type
+               continue
             if not isinstance(handshake.data, dpkt.ssl.TLSClientHello):
                 # Still not the HELLO
                 continue

--- a/python/ja3s.py
+++ b/python/ja3s.py
@@ -123,6 +123,10 @@ def process_pcap(pcap, any_port=False):
             except dpkt.dpkt.NeedData:
                 # Looking for a handshake here
                 continue
+            except dpkt.ssl.SSL3Exception:
+                #Unknown or invalid cypher suite type
+               continue
+
             if not isinstance(handshake.data, dpkt.ssl.TLSServerHello):
                 # Still not the HELLO
                 continue


### PR DESCRIPTION
dpkt.ssl.SSL3Exception occurs when the cypher suite is invalid or unknown. The exception arises in the TLSClientHello class in dpkt library's ssl.py module. A quick fix is adding the exception clause to catch the exception.