### PR TITLE
ja3: next should be return

### DIFF
--- a/zeek/ja3.zeek
+++ b/zeek/ja3.zeek
@@ -66,7 +66,7 @@ if ( ! c?$tlsfp )
     c$tlsfp=TLSFPStorage();
     if ( is_orig == T ) {
         if ( code in grease ) {
-            next;
+            return;
         }
         if ( c$tlsfp$extensions == "" ) {
             c$tlsfp$extensions = cat(code);


### PR DESCRIPTION
This makes the Zeek scripts Zeek 5.2 compatible due to now validating whether next and break statements are used in the right context.